### PR TITLE
parser fix: allowing empty predicate bodies

### DIFF
--- a/src/main/scala/gvc/parser/Definitions.scala
+++ b/src/main/scala/gvc/parser/Definitions.scala
@@ -74,7 +74,7 @@ trait Definitions extends Statements with Types {
     P(space ~~ predicateDefinition.rep ~~ space)
 
   def predicateDefinition[_: P]: P[PredicateDefinition] =
-    P(span("predicate" ~ identifier ~ "(" ~ methodParameter.rep(sep = ",") ~ ")" ~/ predicateBody))
+    P(span("predicate" ~ identifier ~ "(" ~ methodParameter.rep(sep = ",") ~ ")" ~/ (predicateBody | emptyPredicateBody)))
     .map { case ((ident, args, body), span) => PredicateDefinition(ident, args.toList, body, span) }
   
   def emptyPredicateBody[_: P]: P[Option[Expression]] = P(";").map(_ => None)


### PR DESCRIPTION
Quick commit fix that allows predicates to be parsed if they are declared and used in other predicates without defining its body. Necessary for mutually recursive predicates.

Conrad please make sure this is a correct fix. If it is please merge this branch into master, close this pull request, and delete the branch. Thanks!! 