### PR TITLE
Allow multiple `--recreate` permutations at once

### DIFF
--- a/src/main/scala/gvc/Config.scala
+++ b/src/main/scala/gvc/Config.scala
@@ -37,7 +37,7 @@ case class Config(
     dbURLString: Option[String] = None,
     dbUserString: Option[String] = None,
     dbPassString: Option[String] = None,
-    recreatePerm: Option[Int] = None
+    recreatePerms: List[Int] = List.empty
 ) {
   def validate(): Unit = {
     (
@@ -266,7 +266,7 @@ object Config {
         fromCommandLineArgs(
           tail,
           current.copy(
-            recreatePerm = Some(this.parseInt(t, "--recreate")),
+            recreatePerms = this.parseInt(t, "--recreate") :: current.recreatePerms,
             mode = Recreate
           )
         )

--- a/src/main/scala/gvc/benchmarking/BenchmarkExternalConfig.scala
+++ b/src/main/scala/gvc/benchmarking/BenchmarkExternalConfig.scala
@@ -54,7 +54,7 @@ case class PipelineModifiers(exclusiveMode: Option[DynamicMeasurementMode],
 case class RecreatorConfig(version: String,
                            db: BenchmarkDBCredentials,
                            sources: List[Path],
-                           permToRecreate: Long,
+                           permsToRecreate: List[Int],
                            modifiers: PipelineModifiers)
     extends BenchmarkingConfig
 
@@ -127,15 +127,11 @@ object BenchmarkExternalConfig {
 
   def parseRecreator(rootConfig: Config): RecreatorConfig = {
     val resolved = parseConfig(rootConfig)
-    rootConfig.recreatePerm match {
-      case Some(value) =>
-        RecreatorConfig(resolved.version,
-                        resolved.credentials,
-                        resolved.sources,
-                        value,
-                        resolved.modifiers)
-      case None => error("Expected an integer value passed to --recreate.")
-    }
+    RecreatorConfig(resolved.version,
+                    resolved.credentials,
+                    resolved.sources,
+                    rootConfig.recreatePerms,
+                    resolved.modifiers)
   }
 
   def parseExecutor(rootConfig: Config): ExecutorConfig = {

--- a/src/main/scala/gvc/benchmarking/BenchmarkRecreator.scala
+++ b/src/main/scala/gvc/benchmarking/BenchmarkRecreator.scala
@@ -14,13 +14,14 @@ object BenchmarkRecreator {
 
   def recreate(config: RecreatorConfig,
                baseConfig: Config,
-               libraries: List[String]): Recreated = {
-    val conn = DAO.connect(config.db)
-    val permutation = DAO.resolvePermutation(config.permToRecreate, conn)
+               libraries: List[String],
+               conn: DAO.DBConnection,
+               permToRecreate: Int): Recreated = {
+    val permutation = DAO.resolvePermutation(permToRecreate, conn)
 
     permutation match {
       case Some(perm) =>
-        Output.success(s"Located permutation #${config.permToRecreate}")
+        Output.success(s"Located permutation #${permToRecreate}")
 
         if (config.modifiers.skipVerification) {
           DAO.resolveVersion(config.version, conn) match {
@@ -50,7 +51,7 @@ object BenchmarkRecreator {
 
       case None =>
         error(
-          s"A permutation with ID=${baseConfig.recreatePerm.get} does not exist in the database.")
+          s"A permutation with ID=${permToRecreate} does not exist in the database.")
     }
   }
 }


### PR DESCRIPTION
It's pretty slow to spin up a new process and database connection for every permutation to recreate, so this PR allows multiple instances of the `--recreate` CLI argument to be passed.

The only change in this PR I'm not quite sure about is the removal of the `else { sys.exit(0) }` branch at the end of the `Main.execute` method.