### PR TITLE
Allow multiple files in `DefaultMode`

### DIFF
--- a/src/main/scala/gvc/Config.scala
+++ b/src/main/scala/gvc/Config.scala
@@ -28,7 +28,7 @@ case class Config(
     onlyCompile: Boolean = false,
     onlyBenchmark: Boolean = false,
     onlyErrors: Boolean = false,
-    sourceFile: Option[String] = None,
+    sourceFiles: List[String] = List.empty,
     linkedLibraries: List[String] = List.empty,
     includeDirectories: List[String] = List.empty,
     versionString: Option[String] = None,
@@ -52,14 +52,24 @@ case class Config(
         Some("Cannot combine --output and --only-verify")
       else if (exec && onlyVerify)
         Some("Cannot combine --exec and --only-verify")
-      else if (sourceFile.isEmpty && (mode == DefaultMode || mode == Describe || mode == CaseStudyMode))
+      else if (sourceFiles.isEmpty && (mode == DefaultMode || mode == Describe || mode == CaseStudyMode))
         Some("No source file specified")
-      else if (sourceFile.nonEmpty && !Files.exists(Paths.get(sourceFile.get)))
-        Some(s"Source file '${sourceFile.get}' does not exist")
+      else if (sourceFiles.nonEmpty)
+        sourceFiles.collectFirst {
+          case sourceFile if !Files.exists(Paths.get(sourceFile)) =>
+            s"Source file '${sourceFile}' does not exist"
+        }
       else if (versionString.nonEmpty && versionString.get.trim.isEmpty) {
         Some(s"Invalid version string.")
       } else None
     ).foreach(Config.error)
+  }
+
+  def getSingleSourceFile(): String = {
+    if (sourceFiles.size > 1) {
+      Config.error("Cannot specify multiple input files")
+    }
+    sourceFiles.head
   }
 }
 
@@ -359,14 +369,10 @@ object Config {
       case other :: _ if other.startsWith("-") =>
         error(s"Unrecognized command line argument: $other")
       case sourceFile :: tail =>
-        current.sourceFile match {
-          case Some(_) => error("Cannot specify multiple input files")
-          case None =>
-            fromCommandLineArgs(
-              tail,
-              current.copy(sourceFile = Some(sourceFile))
-            )
-        }
+        fromCommandLineArgs(
+          tail,
+          current.copy(sourceFiles = sourceFile :: current.sourceFiles)
+        )
       case Nil => current
     }
 

--- a/src/main/scala/gvc/benchmarking/BenchmarkExternalConfig.scala
+++ b/src/main/scala/gvc/benchmarking/BenchmarkExternalConfig.scala
@@ -253,9 +253,10 @@ object BenchmarkExternalConfig {
           p.getName.endsWith(".c0")
         })
         .map(_.toPath)
-      val fileCollection = rootConfig.sourceFile match {
-        case Some(value) => c0SourceFiles ++ List(Paths.get(value))
-        case None        => c0SourceFiles
+      val fileCollection = rootConfig.sourceFiles match {
+        case List(value) => c0SourceFiles ++ List(Paths.get(value))
+        case List()      => c0SourceFiles
+        case _ => Config.error("Cannot specify multiple input files")
       }
 
       val outputDir = benchmarkRoot \ "output-dir"


### PR DESCRIPTION
Similar to #60, it's nice to be able to run on multiple files in sequence, because having to do `sbt run` for every individual file adds a lot of time.